### PR TITLE
send version information to stdout instead of stderr to prevent console window to pop up in ImageJ

### DIFF
--- a/src/org/scijava/java3d/VirtualUniverse.java
+++ b/src/org/scijava/java3d/VirtualUniverse.java
@@ -233,8 +233,8 @@ ArrayList<Integer> viewIdFreeList = new ArrayList<Integer>();
             if (isLoggableConfig) {
                 logger.config(str);
             } else {
-                System.err.println(str);
-                System.err.println();
+                System.out.println(str);
+                System.out.println();
             }
 	}
 


### PR DESCRIPTION
Hey guys,

I would like to get rid of the annoying popup window showing the console in ImageJ, whenever I run the 3D Viewer. In order to do this, I changed the destination of a print command from stderr to stdout. Whoever wants to know the version of Java3D can open the console and look it up. However, normal users are then no longer disturbed by the popping up console.

Cheers,
Robert
